### PR TITLE
Phase 2: SRS ingestion and rule-driven planning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Output is then transcribed by `pom.ts` (default — full POM framework) or `tran
 
 25. **`/heal <spec-path>` repairs an existing spec through the published `qa-core-heal` npm package. There is no in-repo heal engine.** `npm run heal -- <spec-path> [--base-url <url>] [--dry-run]` runs `src/cli/heal.ts`, a thin wrapper that parses the arguments, forwards them to `heal()` from the package, and prints the report. The wrapper contains no selector logic. The import is the deep path `qa-core-heal/dist/heal.js` on purpose: qa-core-heal 0.3.4 publishes no `main`/`exports` entry, only a bin, so the bare specifier does not resolve. The gateway `/heal` and MCP `qa_heal` import `heal` from the wrapper module, so every heal path goes through the same package integration. The package is deterministic (no LLM, no spec run): it probes every locator on the live page, re-resolves broken ones by semantic intent, refuses ambiguous or wrong-element matches, writes confirmed heals back in place, and reports every unhealable selector. Package docs: [npmjs.com/package/qa-core-heal](https://www.npmjs.com/package/qa-core-heal)
 
+26. **SRS ingestion is additive: without `--srs`, the Planner's input and output format are byte-identical to before this phase.** With `--srs <file>` (`.md`/`.txt` direct, `.pdf` via pdf-parse, `.docx` via mammoth, 60,000-character cap), `src/agent/requirements.ts` builds a `RequirementsMap` in one Haiku call (features with per-feature rules `R1..Rn` typed validation/behavior/permission/navigation, plus roles; only what the SRS states, URLs and rules never invented; malformed JSON gets one "return only valid JSON" retry then a clear error, and `parseRequirementsResponse` is exported so the recovery path is testable offline). The map is written to `requirements-map.json`, and an SRS whose feature list comes back empty fails the run BEFORE the browser launches. In the Planner the map arrives as a second system block appended AFTER the cached base SYSTEM (cache prefix untouched): planning becomes rule-first (stated rules over DOM evidence), each rule-verifying scenario cites its rule ids in a THIRD bracket (`[login][negative][R3,R7] ...`, page-discovered scenarios use `[-]`), and the ceiling becomes up to 4 scenarios per map feature. `parsePlan` (now exported) reads the bracket into `PlannedScenario.ruleIds` and tolerates its absence: a two-bracket or legacy line parses exactly as before with NO `ruleIds` key. `--features` wins for feature selection when both are set; the map still steers rules. Rule ids carry through `Scenario.ruleIds` into the RunReport (attached by name-match in `runtime.ts`), and `src/agent/rule-coverage.ts` classifies every rule as covered / planned-but-dropped / not-planned, written to `rule-coverage.json` and printed as `Rule coverage: X of Y rules covered` with the uncovered list (the considered-not-automated report). `slimFrameworkDir` preserves `requirements-map.json` and `rule-coverage.json` alongside `run-report.json`. Locked by `smoke-srs-parse`, `smoke-plan-rule-tags` (the no-`--srs` byte-identical invariant), and `smoke-rule-coverage`.
+
 ---
 
 ## Standard verification (run before claiming "done")
@@ -96,7 +98,8 @@ for s in smoke-tools smoke-finish smoke-hascount smoke-planner-parse \
          smoke-unique-data smoke-closeout-grace smoke-step-budget \
          smoke-table-gate smoke-circular smoke-compare-poll smoke-iframe \
          smoke-planner-iframe smoke-frame-value smoke-fill-verify \
-         smoke-pom-ambiguous smoke-filter-disambiguation smoke-selector-recovery; do
+         smoke-pom-ambiguous smoke-filter-disambiguation smoke-selector-recovery \
+         smoke-srs-parse smoke-plan-rule-tags smoke-rule-coverage; do
   echo "=== $s ==="
   npx tsx scripts/$s.ts
 done

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ test("[happy] logged in with valid credentials", async ({ page }) => {
 
 If you prefer a single-file output without the page object, pass `--no-pom`.
 
+Other useful flags: `--features login,cart` limits planning to those features, and `--srs requirements.md` feeds a requirements document into the run (see the SRS-first workflow below).
+
 ### Review mode (sign-off before automation)
 
 For team workflows where a lead needs to approve scenarios before the Explorer runs:
@@ -250,7 +252,40 @@ npm run generate -- "As a user I want to log in so I can access my dashboard"
 npm run generate -- "..." --lang js --base-url https://staging.example.com
 ```
 
-This one does not open a browser. It produces code from acceptance criteria. Run the spec to verify it works against your real app.
+This one does not open a browser. It produces code from acceptance criteria. Run the spec to verify it works against your real app. Pass `--srs requirements.md` to inject the documented rules as context, so the generated tests verify the stated constraints and not just the story text.
+
+### SRS-first workflow (test what the document says)
+
+Give the agent your requirements document and it understands the functionality before planning a single test:
+
+```bash
+npm run explore -- https://your-app.example.com --srs docs/requirements.md
+```
+
+1. The SRS is loaded (`.md`, `.txt`, `.pdf`, or `.docx`; capped at 60,000 characters) and one cheap Haiku call converts it into a requirements map: features, per-feature rules with stable ids (R1, R2, ...), and the roles the document names. Only what the SRS states is extracted; URLs and rules are never invented.
+2. The map is written to `requirements-map.json` in the run directory and injected into the Planner, which now plans rule-first: scenarios are derived from the stated rules, and each scenario cites the rule ids it verifies in a third bracket, like `[login][negative][R3,R7] rejected a 5-character password`. A scenario discovered from the page with no matching rule is tagged `[-]`. With a map present the Planner may plan up to 4 scenarios per feature.
+3. The run ends with a rule-coverage report: `rule-coverage.json` plus a console summary (`Rule coverage: X of Y rules covered`). Every uncovered rule is listed with why (`not-planned`, or `planned-but-dropped` when the citing scenario did not survive replay and stability). That list is the "considered, not automated" report.
+
+The map shape:
+
+```typescript
+{
+  features: Array<{
+    name: string;          // kebab-case slug, e.g. "login"
+    description: string;   // one sentence
+    urls?: string[];       // only when the SRS states them
+    rules: Array<{
+      id: string;          // R1, R2... unique across the map
+      text: string;        // the rule in plain words
+      type: 'validation' | 'behavior' | 'permission' | 'navigation';
+    }>;
+  }>;
+  roles: string[];         // roles the SRS names, empty if none
+  truncated: boolean;      // true when the document was cut at the cap
+}
+```
+
+`--features` still wins for feature selection when both flags are set; the SRS rules keep steering the Planner either way. Without `--srs`, nothing changes: the Planner's input and output are exactly as before.
 
 ### Heal a spec that broke
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -519,6 +519,8 @@ npm run explore -- <url>
                    [--out <dir>]             base output directory (default: ./output)
                    [--review]                pause after Planner, write plan.csv
                    [--from-plan <csv>]       skip Planner, read approved scenarios from a previous review
+                   [--features a,b]          limit planning to these features
+                   [--srs <file>]            requirements document (.md/.txt/.pdf/.docx) for rule-driven planning
 ```
 
 **Examples:**
@@ -542,6 +544,7 @@ npm run generate -- "<story>"
                     [--lang ts|js]            output language (default: ts)
                     [--base-url <url>]        optional base URL baked into the spec
                     [--out <dir>]             base output directory
+                    [--srs <file>]            requirements document injected as rule context
 ```
 
 **Examples:**
@@ -552,6 +555,23 @@ npm run generate -- "..." --lang js --base-url https://staging.example.com
 ```
 
 The output spec carries an UNVERIFIED header until you run it.
+
+---
+
+### SRS-first workflow (`--srs`)
+
+Both `/explore` and `/generate` accept a requirements document, so the agent understands the stated functionality before planning tests.
+
+```bash
+npm run explore -- https://your-app.example.com --srs docs/requirements.md
+```
+
+1. **Load.** `.md` and `.txt` are read directly; `.pdf` via pdf-parse; `.docx` via mammoth. Text is capped at 60,000 characters (a longer document is cut and flagged `truncated: true`). Any other extension is rejected with an error naming the supported ones.
+2. **Map.** One Haiku call (`src/agent/requirements.ts`) converts the text into a `RequirementsMap`: features (kebab-case name, one-sentence description, URLs only when stated), per-feature rules with ids `R1..Rn` unique across the map and a type (`validation` / `behavior` / `permission` / `navigation`), and the roles the SRS names. Only what the document states is extracted; rules and URLs are never invented. The map is written to `requirements-map.json` in the run directory. An SRS that yields no features stops the run before the browser launches.
+3. **Plan from rules.** The Planner receives the map as a REQUIREMENTS system block and plans rule-first: scenarios derive from the stated rules, DOM evidence second, and every rule-verifying scenario cites its rule ids in a third bracket, e.g. `[login][negative][R3,R7] rejected a 5-character password`. A page-discovered scenario with no matching rule uses `[-]`. With a map present the ceiling is up to 4 scenarios per map feature. `--features` wins for feature selection when both flags are set; the rules still steer.
+4. **Report coverage.** Rule ids carry through the pipeline into the RunReport. The run ends with `rule-coverage.json` and a console summary (`Rule coverage: X of Y rules covered`); every uncovered rule is listed as `not-planned` or `planned-but-dropped` (a citing scenario existed but did not survive replay/stability). This is the considered-not-automated report.
+
+Without `--srs`, planner input and output are unchanged from the pre-SRS behaviour.
 
 ---
 
@@ -777,6 +797,8 @@ Each run writes to `output/<run-id>/`. The run ID format is `<YYYYMMDD>-<HHMMSS>
 |---|---|---|
 | `<name>.spec.ts` or `.js` | Playwright spec | The generated test suite |
 | `run-report.json` | JSON | Scenarios, cost per stage, cascade stats, Critic verdicts, timings |
+| `requirements-map.json` | JSON | The RequirementsMap built from the SRS (only with `--srs`) |
+| `rule-coverage.json` | JSON | Covered / uncovered rules with reasons (only with `--srs`) |
 
 ### From `/explore --review`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.48.0",
         "dotenv": "^16.4.5",
+        "mammoth": "^1.12.2",
+        "pdf-parse": "^1.1.4",
         "playwright": "^1.48.0",
         "qa-core-heal": "^0.3.4",
         "ws": "^8.20.0",
@@ -21,6 +23,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/pdf-parse": "^1.1.5",
         "@types/ws": "^8.18.1",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0"
@@ -599,6 +602,16 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -607,6 +620,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -704,6 +726,15 @@
         }
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -718,6 +749,32 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -846,6 +903,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -912,6 +975,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -922,6 +991,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1445,6 +1523,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1475,6 +1559,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1501,6 +1591,62 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.2.tgz",
+      "integrity": "sha512-MH2vkgafD/2MYUaEOtoXLKrHQZ7yLYTHGQgyLNtYZHiUxU1K1QQ+8qMFquDAfhBm06wSGSws3J+Q9QTsKtR44g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1588,6 +1734,12 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -1650,6 +1802,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1657,6 +1821,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -1676,6 +1849,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
       }
     },
     "node_modules/pkce-challenge": {
@@ -1716,6 +1905,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1804,6 +1999,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1838,6 +2048,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1914,6 +2130,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2014,6 +2236,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2021,6 +2249,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/toidentifier": {
@@ -2143,6 +2380,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -2157,6 +2400,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -2232,6 +2481,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.48.0",
     "dotenv": "^16.4.5",
+    "mammoth": "^1.12.2",
+    "pdf-parse": "^1.1.4",
     "playwright": "^1.48.0",
     "qa-core-heal": "^0.3.4",
     "ws": "^8.20.0",
@@ -50,6 +52,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/pdf-parse": "^1.1.5",
     "@types/ws": "^8.18.1",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"

--- a/scripts/smoke-plan-rule-tags.ts
+++ b/scripts/smoke-plan-rule-tags.ts
@@ -1,0 +1,79 @@
+/**
+ * Locks the plan parser on the rule-citation bracket (src/agent/planner.ts).
+ *
+ * The rule-driven format adds an OPTIONAL third bracket after the category:
+ *   "1. [login][negative][R3,R7] name — rationale"   → ruleIds ['R3','R7']
+ *   "2. [login][edge][-] name — rationale"           → ruleIds [] (no matching rule)
+ * Without a requirements map the Planner never emits the bracket, and the old
+ * two-bracket and legacy formats must parse EXACTLY as before — same fields,
+ * no ruleIds key at all. That is the no-SRS zero-behavior-change invariant.
+ *
+ * This drives the REAL exported parsePlan, not a mirror.
+ */
+import { parsePlan } from '../src/agent/planner.js';
+
+let pass = 0;
+let fail = 0;
+const check = (label: string, ok: boolean, hint?: string): void => {
+  if (ok) { pass++; console.log(`OK  ${label}`); }
+  else { fail++; console.log(`FAIL ${label}${hint ? ' — ' + hint : ''}`); }
+};
+
+/* ─── A. three-bracket format with rule ids ────────────────────────────────── */
+const withRules = parsePlan('<plan>\n1. [login][negative][R3,R7] rejected a 5-character password — fails if the length rule stops being enforced\n</plan>');
+check('A1. line parses', withRules.length === 1);
+const a = withRules[0]!;
+check('A2. feature parsed', a.feature === 'login');
+check('A3. category parsed', a.category === 'negative');
+check('A4. ruleIds parsed in order', JSON.stringify(a.ruleIds) === '["R3","R7"]', JSON.stringify(a.ruleIds));
+check('A5. name is clean (no bracket residue)', a.name === 'rejected a 5-character password', a.name);
+check('A6. rationale parsed', a.rationale.startsWith('fails if the length rule'));
+
+/* ─── B. lowercase / spaced ids normalize ──────────────────────────────────── */
+const spaced = parsePlan('1. [cart][happy][r2, r10] added an item and the badge went up — fails if add-to-cart stops writing state');
+check('B1. lowercase + spaced ids normalize to R2,R10', JSON.stringify(spaced[0]?.ruleIds) === '["R2","R10"]', JSON.stringify(spaced[0]?.ruleIds));
+
+/* ─── C. [-] means planned with a map but no matching rule ─────────────────── */
+const dash = parsePlan('2. [login][edge][-] password field masks input — fails if the field renders the password as plain text');
+check('C1. [-] parses', dash.length === 1);
+check('C2. [-] yields an EMPTY ruleIds array (present, not absent)', Array.isArray(dash[0]?.ruleIds) && dash[0]!.ruleIds!.length === 0, JSON.stringify(dash[0]));
+check('C3. name is clean after [-]', dash[0]!.name === 'password field masks input', dash[0]!.name);
+
+/* ─── D. the old two-bracket format parses unchanged: no ruleIds key at all ── */
+const OLD_LINE = '1. [login][happy] logged in with valid credentials — fails if the success path stops landing on the inventory page';
+const old = parsePlan(OLD_LINE);
+check('D1. two-bracket line parses', old.length === 1);
+const d = old[0]!;
+check('D2. fields identical to the pre-SRS parse', d.feature === 'login' && d.category === 'happy' && d.name === 'logged in with valid credentials' && d.rationale.startsWith('fails if the success path'));
+check('D3. ruleIds key is ABSENT (not empty, not undefined-assigned)', !('ruleIds' in d), JSON.stringify(d));
+
+/* ─── E. legacy no-feature variants still parse, also without ruleIds ──────── */
+const legacyVariants = [
+  '1. [happy] logged in — fails if login breaks',
+  '2. happy logged in — fails if login breaks',
+  '3. happy — logged in — fails if login breaks',
+  '4. happy: logged in — fails if login breaks',
+];
+for (const [i, line] of legacyVariants.entries()) {
+  const p = parsePlan(line);
+  check(`E${i + 1}. legacy variant ${i + 1} parses without ruleIds`, p.length === 1 && p[0]!.category === 'happy' && !('ruleIds' in p[0]!), line);
+}
+
+/* ─── F. a mixed plan block parses every format side by side ───────────────── */
+const mixed = parsePlan(`<plan>
+1. [login][negative][R3] rejected a wrong password — fails if a wrong password is accepted
+2. [login][edge][-] password field masks input — fails if the password renders as plain text
+3. [cart][happy] added item to cart — fails if the badge stops updating
+</plan>`);
+check('F1. all three lines parse', mixed.length === 3);
+check('F2. rule-cited line has its ids', JSON.stringify(mixed[0]?.ruleIds) === '["R3"]');
+check('F3. [-] line has empty ids', Array.isArray(mixed[1]?.ruleIds) && mixed[1]!.ruleIds!.length === 0);
+check('F4. two-bracket line has no ruleIds key', !('ruleIds' in mixed[2]!));
+
+/* ─── G. malformed rule brackets do not break the line ─────────────────────── */
+const junk = parsePlan('1. [login][negative][R3;R7] rejected a wrong password — fails if a wrong password is accepted');
+check('G1. an unparseable rule bracket falls through without crashing', junk.length === 1, JSON.stringify(junk));
+
+console.log(`\n${pass}/${pass + fail} checks passed.`);
+if (fail > 0) process.exit(1);
+console.log('OK: the rule-citation bracket parses ids and [-], and the pre-SRS formats parse byte-identically with no ruleIds key.');

--- a/scripts/smoke-rule-coverage.ts
+++ b/scripts/smoke-rule-coverage.ts
@@ -1,0 +1,105 @@
+/**
+ * Locks the rule-coverage classifier (src/agent/rule-coverage.ts):
+ *   - covered            → a surviving scenario cites the rule
+ *   - planned-but-dropped → a planned scenario cited the rule, none survived
+ *   - not-planned        → no planned scenario cited the rule
+ * plus the rendered "X of Y rules covered" summary and the named uncovered
+ * list (the "considered, not automated" report).
+ *
+ * Pure in-code fixtures. No network. No LLM. No browser.
+ */
+import { computeRuleCoverage, renderRuleCoverage } from '../src/agent/rule-coverage.js';
+import type { RequirementsMap } from '../src/agent/requirements.js';
+
+let pass = 0;
+let fail = 0;
+const check = (label: string, ok: boolean, hint?: string): void => {
+  if (ok) { pass++; console.log(`OK  ${label}`); }
+  else { fail++; console.log(`FAIL ${label}${hint ? ' — ' + hint : ''}`); }
+};
+
+const map: RequirementsMap = {
+  features: [
+    {
+      name: 'login',
+      description: 'Users sign in with email and password.',
+      rules: [
+        { id: 'R1', text: 'The password must be at least 8 characters.', type: 'validation' },
+        { id: 'R2', text: 'After a successful login the user lands on the dashboard.', type: 'navigation' },
+        { id: 'R3', text: 'Only admins may open the settings page.', type: 'permission' },
+      ],
+    },
+    {
+      name: 'cart',
+      description: 'A shopper collects items before checkout.',
+      rules: [
+        { id: 'R4', text: 'Adding an item increments the cart badge.', type: 'behavior' },
+      ],
+    },
+  ],
+  roles: ['admin'],
+  truncated: false,
+};
+
+// The plan cited R1 (two scenarios), R2 (one scenario), and R4. R3 was never
+// planned. The R2 scenario and one R1 scenario did not survive the pipeline.
+const planned = [
+  { name: 'rejected a 5-character password', ruleIds: ['R1'] },
+  { name: 'rejected a 7-character password on the edge', ruleIds: ['R1'] },
+  { name: 'landed on the dashboard after login', ruleIds: ['R2'] },
+  { name: 'added an item and the badge went up', ruleIds: ['R4'] },
+  { name: 'password field masks input', ruleIds: [] },
+];
+
+// Final report: one R1 scenario survived, the R4 scenario survived, the R2
+// scenario was dropped at replay, the [-] scenario survived citing nothing.
+const scenarios = [
+  { name: 'rejected a 5-character password', ruleIds: ['R1'] },
+  { name: 'added an item and the badge went up', ruleIds: ['R4'] },
+  { name: 'password field masks input' },
+];
+
+const coverage = computeRuleCoverage({ map, planned, scenarios });
+
+/* ─── A. covered ───────────────────────────────────────────────────────────── */
+const coveredIds = coverage.covered.map((c) => c.ruleId).sort();
+check('A1. R1 and R4 are covered', JSON.stringify(coveredIds) === '["R1","R4"]', JSON.stringify(coverage.covered));
+const r1 = coverage.covered.find((c) => c.ruleId === 'R1');
+check('A2. a covered rule names its surviving scenario(s)', r1 !== undefined && JSON.stringify(r1.scenarios) === '["rejected a 5-character password"]', JSON.stringify(r1));
+
+/* ─── B. planned-but-dropped ───────────────────────────────────────────────── */
+const r2 = coverage.uncovered.find((u) => u.ruleId === 'R2');
+check('B1. R2 is uncovered', r2 !== undefined);
+check('B2. R2 is classified planned-but-dropped', r2?.reason === 'planned-but-dropped', JSON.stringify(r2));
+check('B3. the uncovered entry carries the rule text', r2?.text.includes('dashboard') === true);
+
+/* ─── C. not-planned ───────────────────────────────────────────────────────── */
+const r3 = coverage.uncovered.find((u) => u.ruleId === 'R3');
+check('C1. R3 is uncovered', r3 !== undefined);
+check('C2. R3 is classified not-planned', r3?.reason === 'not-planned', JSON.stringify(r3));
+
+/* ─── D. totals + rendered summary ─────────────────────────────────────────── */
+check('D1. covered + uncovered account for every rule', coverage.covered.length + coverage.uncovered.length === 4);
+const lines = renderRuleCoverage(coverage);
+check('D2. summary line reads "2 of 4 rules covered"', lines[0] === 'Rule coverage: 2 of 4 rules covered', lines[0]);
+check('D3. the uncovered list names both rules with reasons',
+  lines.some((l) => l.includes('R2') && l.includes('planned-but-dropped')) && lines.some((l) => l.includes('R3') && l.includes('not-planned')),
+  JSON.stringify(lines));
+
+/* ─── E. full coverage renders with no uncovered section ───────────────────── */
+const full = computeRuleCoverage({
+  map,
+  planned,
+  scenarios: [
+    { name: 's1', ruleIds: ['R1'] },
+    { name: 's2', ruleIds: ['R2'] },
+    { name: 's3', ruleIds: ['R3'] },
+    { name: 's4', ruleIds: ['R4'] },
+  ],
+});
+check('E1. all four covered', full.covered.length === 4 && full.uncovered.length === 0);
+check('E2. rendered summary is a single line when nothing is uncovered', renderRuleCoverage(full).length === 1);
+
+console.log(`\n${pass}/${pass + fail} checks passed.`);
+if (fail > 0) process.exit(1);
+console.log('OK: rule coverage classifies covered, planned-but-dropped, and not-planned correctly and renders the considered-not-automated report.');

--- a/scripts/smoke-srs-parse.ts
+++ b/scripts/smoke-srs-parse.ts
@@ -1,0 +1,115 @@
+/**
+ * Locks SRS ingestion (src/agent/requirements.ts), without any LLM call:
+ *   - loadSrsText reads a .md file directly.
+ *   - The 60,000-character cap truncates and reports truncated=true.
+ *   - An unsupported extension is rejected with an error naming the
+ *     supported ones.
+ *   - parseRequirementsResponse (the parse step behind buildRequirementsMap)
+ *     recovers a fenced response, accepts a clean response, tolerates prose
+ *     around the JSON, normalizes feature names to kebab-case, renumbers
+ *     colliding rule ids, and throws clearly on a malformed response.
+ *
+ * No network. No LLM. Temp files only.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadSrsText, parseRequirementsResponse, SRS_TEXT_CAP } from '../src/agent/requirements.js';
+
+let pass = 0;
+let fail = 0;
+const check = (label: string, ok: boolean, hint?: string): void => {
+  if (ok) { pass++; console.log(`OK  ${label}`); }
+  else { fail++; console.log(`FAIL ${label}${hint ? ' — ' + hint : ''}`); }
+};
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qa-core-srs-'));
+
+const FIXTURE_SRS = `# Login requirements
+
+The login page is at /login.
+
+- The password must be at least 8 characters.
+- The email field is required.
+- After a successful login the user lands on the dashboard.
+- Only admins may open the settings page.
+`;
+
+/* ─── A. .md loads directly, no truncation ─────────────────────────────────── */
+const mdPath = path.join(tmpRoot, 'srs.md');
+fs.writeFileSync(mdPath, FIXTURE_SRS);
+const loaded = await loadSrsText(mdPath);
+check('A1. .md loads the exact text', loaded.text === FIXTURE_SRS);
+check('A2. under the cap is not truncated', loaded.truncated === false);
+
+/* ─── B. the 60k cap truncates and reports it ──────────────────────────────── */
+const bigPath = path.join(tmpRoot, 'big.txt');
+fs.writeFileSync(bigPath, 'R'.repeat(SRS_TEXT_CAP + 5_000));
+const big = await loadSrsText(bigPath);
+check('B1. oversized text is cut at the cap', big.text.length === SRS_TEXT_CAP);
+check('B2. truncation is recorded', big.truncated === true);
+
+/* ─── C. unsupported extension fails with a clear error ────────────────────── */
+const rtfPath = path.join(tmpRoot, 'srs.rtf');
+fs.writeFileSync(rtfPath, 'not supported');
+let rtfError = '';
+try { await loadSrsText(rtfPath); } catch (err) { rtfError = (err as Error).message; }
+check('C1. .rtf is rejected', rtfError.length > 0);
+check('C2. the error names the supported extensions', ['.md', '.txt', '.pdf', '.docx'].every((e) => rtfError.includes(e)), rtfError);
+
+/* ─── D. parse step: clean response ────────────────────────────────────────── */
+const CLEAN = JSON.stringify({
+  features: [
+    {
+      name: 'login',
+      description: 'Users sign in with email and password.',
+      urls: ['/login'],
+      rules: [
+        { id: 'R1', text: 'The password must be at least 8 characters.', type: 'validation' },
+        { id: 'R2', text: 'The email field is required.', type: 'validation' },
+      ],
+    },
+  ],
+  roles: ['admin'],
+});
+const clean = parseRequirementsResponse(CLEAN);
+check('D1. clean JSON parses', clean.features.length === 1 && clean.features[0]!.name === 'login');
+check('D2. rules survive with id + type', clean.features[0]!.rules.length === 2 && clean.features[0]!.rules[0]!.id === 'R1' && clean.features[0]!.rules[0]!.type === 'validation');
+check('D3. stated urls survive', (clean.features[0]!.urls ?? []).includes('/login'));
+check('D4. roles survive', clean.roles.includes('admin'));
+
+/* ─── E. parse step: fenced response is recovered ──────────────────────────── */
+const fenced = parseRequirementsResponse('```json\n' + CLEAN + '\n```');
+check('E1. a ```json fence is stripped', fenced.features.length === 1 && fenced.features[0]!.rules.length === 2);
+const withProse = parseRequirementsResponse('Here is the requirements map you asked for:\n\n' + CLEAN + '\n\nLet me know if you need anything else.');
+check('E2. prose around the JSON object is tolerated', withProse.features.length === 1);
+
+/* ─── F. parse step: normalization + id repair ─────────────────────────────── */
+const MESSY = JSON.stringify({
+  features: [
+    { name: 'User Registration', description: 'x', rules: [{ id: 'R1', text: 'a', type: 'validation' }, { id: 'R1', text: 'b', type: 'weird-type' }] },
+    { name: 'cart', description: 'y', rules: [{ text: 'c', type: 'behavior' }] },
+  ],
+  roles: [],
+});
+const messy = parseRequirementsResponse(MESSY);
+check('F1. feature names normalize to kebab-case', messy.features[0]!.name === 'user-registration');
+const allIds = messy.features.flatMap((f) => f.rules.map((r) => r.id));
+check('F2. colliding/missing ids are renumbered unique', new Set(allIds).size === allIds.length && allIds.every((id) => /^R\d+$/.test(id)), JSON.stringify(allIds));
+check('F3. an unknown rule type falls back to behavior', messy.features[0]!.rules[1]!.type === 'behavior');
+check('F4. a feature without stated urls has no urls key', !('urls' in messy.features[1]!));
+
+/* ─── G. parse step: malformed responses throw clearly ─────────────────────── */
+const throws = (input: string): string => {
+  try { parseRequirementsResponse(input); return ''; } catch (err) { return (err as Error).message; }
+};
+check('G1. non-JSON throws', throws('this is not json at all').length > 0);
+check('G2. a JSON array (wrong shape) throws', throws('[1,2,3]').length > 0);
+check('G3. an object without features throws', throws('{"roles":[]}').includes('features'));
+check('G4. an object with zero usable features throws', throws('{"features":[{"rules":[]}],"roles":[]}').length > 0);
+
+fs.rmSync(tmpRoot, { recursive: true, force: true });
+
+console.log(`\n${pass}/${pass + fail} checks passed.`);
+if (fail > 0) process.exit(1);
+console.log('OK: SRS loading caps and rejects correctly, and the requirements parser recovers fenced/prose responses and fails loud on malformed ones.');

--- a/src/agent/generate.ts
+++ b/src/agent/generate.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { renderRequirementsBlock, type RequirementsMap } from './requirements.js';
 
 /**
  * /generate — user story → Playwright spec source.
@@ -14,6 +15,12 @@ export interface GenerateOptions {
   language: 'ts' | 'js';
   baseUrl?: string;
   model?: string;
+  /**
+   * Optional requirements map built from an SRS (--srs). When present, the
+   * stated rules are injected as context so the generated scenarios verify
+   * the documented constraints, not just the story text.
+   */
+  requirements?: RequirementsMap;
 }
 
 export interface GenerateResult {
@@ -51,6 +58,12 @@ export async function generateFromStory(opts: GenerateOptions): Promise<Generate
     ? `Emit JavaScript using CommonJS: const { test, expect } = require('@playwright/test'); const AxeBuilder = require('@axe-core/playwright').default;`
     : `Emit TypeScript: import { test, expect } from '@playwright/test'; import AxeBuilder from '@axe-core/playwright';`;
   const baseHint = opts.baseUrl ? `Base URL is ${opts.baseUrl}.` : 'No base URL given — write tests against a relative path.';
+  // Requirements context from --srs: the stated rules steer which scenarios
+  // get written (documented constraints first, the story's phrasing second).
+  const requirementsNote = opts.requirements
+    ? `\n\n${renderRequirementsBlock(opts.requirements)}\n` +
+      `Derive scenarios from these stated rules first. For each rule the story touches, write a test that would fail if that rule broke. Do not invent rules or URLs beyond the ones listed.`
+    : '';
 
   const response = await client.messages.create({
     model,
@@ -58,7 +71,7 @@ export async function generateFromStory(opts: GenerateOptions): Promise<Generate
     // SDK 0.32 typedefs predate cache_control on TextBlockParam; cast to bypass.
     system: [{ type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } } as Anthropic.TextBlockParam],
     messages: [
-      { role: 'user', content: `${langNote}\n${baseHint}\n\nUser story:\n\n${opts.story}` },
+      { role: 'user', content: `${langNote}\n${baseHint}${requirementsNote}\n\nUser story:\n\n${opts.story}` },
     ],
   });
 

--- a/src/agent/parse-features.ts
+++ b/src/agent/parse-features.ts
@@ -45,8 +45,9 @@ export interface ParseFeaturesResult {
  * Normalize a single feature label: trim, lowercase, replace internal
  * whitespace with hyphens. Strip surrounding quotes the user might paste.
  * Keep internal hyphens as-is so "user-profile" survives.
+ * Exported so requirements.ts normalizes SRS feature names the same way.
  */
-function normalize(name: string): string {
+export function normalizeFeatureName(name: string): string {
   return name
     .trim()
     .replace(/^["'`]+|["'`]+$/g, '')
@@ -60,7 +61,7 @@ function tidy(features: string[]): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   for (const f of features) {
-    const n = normalize(f);
+    const n = normalizeFeatureName(f);
     if (!n) continue;
     if (seen.has(n)) continue;
     seen.add(n);

--- a/src/agent/planner.ts
+++ b/src/agent/planner.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { chromium, type Frame, type Page } from 'playwright';
 import { installEvalShim } from './eval-shim.js';
+import { renderRequirementsBlock, type RequirementsMap } from './requirements.js';
 
 /**
  * Planner — Step 1 of the multi-agent pipeline.
@@ -24,6 +25,13 @@ export interface PlannedScenario {
    * infer one from the scenario. Drives per-feature grouping downstream.
    */
   feature?: string;
+  /**
+   * Requirement rule ids this scenario verifies (e.g. ['R3','R7']), parsed
+   * from the third bracket of the rule-driven plan format. An empty array
+   * means the scenario was planned with a map present but matches no stated
+   * rule ([-] in the plan). Absent entirely in the no-map format.
+   */
+  ruleIds?: string[];
 }
 
 export interface PlanResult {
@@ -104,6 +112,22 @@ Notice scenario 4: the page's whole point is that the id regenerates, so the tes
 The first bracket is the FEATURE tag — a short, lowercase, kebab-case noun (e.g. login, cart, search, checkout, registration, forgot-password). Use the feature names the caller asked for verbatim when steering. When inferring on your own, pick the most natural feature name for that page (e.g. "login" for an authentication form).
 
 The second bracket is the CATEGORY (happy, negative, edge, a11y) — same as before.`;
+
+/**
+ * Rule-driven planning instructions, appended as a second system block ONLY
+ * when a requirements map is present. Adjusts the base constraints: rules
+ * come first, scenarios cite rule ids in a third bracket, and the ceiling
+ * becomes per-feature. The falsifiability doctrine is unchanged.
+ */
+const RULE_PLANNING = `Rule-driven planning — these adjust the base constraints when REQUIREMENTS are present:
+- Derive scenarios from the STATED rules first, DOM evidence second. A stated rule you can verify from this page always beats a scenario invented from the page alone.
+- Every scenario that verifies one or more rules MUST cite the rule ids in a THIRD bracket after the category, comma-separated. Example:
+    1. [login][negative][R3,R7] rejected a 5-character password — fails if the length rule stops being enforced
+- A scenario discovered from the page that matches NO stated rule uses [-] as the third bracket:
+    2. [login][edge][-] password field masks input — fails if the field renders the password as plain text
+- Scenario ceiling with a map: up to 4 scenarios per feature listed in REQUIREMENTS (this replaces the 3-6 total constraint). Still at least one happy, one negative, and one edge scenario for every feature whose rules support them; do not force a category a feature's rules give no basis for.
+- Never invent rules, features, or URLs beyond the REQUIREMENTS block.
+- Falsifiability is unchanged: every scenario must still name the concrete regression it catches, and all the banned vacuous shapes remain banned.`;
 
 const PLANNER_PRICE = { in: 1.0, out: 5.0 }; // Haiku 4.5 default
 
@@ -454,6 +478,14 @@ export async function plan(opts: {
    * undefined → infer-from-homepage (legacy behaviour).
    */
   features?: string[];
+  /**
+   * Optional requirements map built from an SRS (--srs). When present, a
+   * REQUIREMENTS system block lists every stated rule, planning becomes
+   * rule-first (scenarios cite rule ids in a third bracket), and the scenario
+   * ceiling rises to up to 4 per map feature. When absent, the Planner's
+   * input and output format are byte-identical to the pre-SRS behaviour.
+   */
+  requirements?: RequirementsMap;
 }): Promise<PlanResult> {
   const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set.');
@@ -506,10 +538,22 @@ export async function plan(opts: {
         contentFrames.map((f, i) => `  frame ${i + 1} (${f.frameChain.join(' > ')}): ${describeFrame(f)}`).join('\n')
       : '';
 
+    // Rule-driven planning: when a requirements map is present, a second system
+    // block lists the stated rules and switches the constraints to rule-first.
+    // It is appended AFTER the cached base SYSTEM block so the cache prefix is
+    // untouched, and it is absent entirely without a map, so the no-SRS prompt
+    // stays byte-identical to the pre-SRS behaviour.
+    const systemBlocks: Anthropic.TextBlockParam[] = [
+      { type: 'text', text: SYSTEM, cache_control: { type: 'ephemeral' } } as Anthropic.TextBlockParam,
+    ];
+    if (opts.requirements) {
+      systemBlocks.push({ type: 'text', text: `${renderRequirementsBlock(opts.requirements)}\n\n${RULE_PLANNING}` } as Anthropic.TextBlockParam);
+    }
+
     const response = await client.messages.create({
       model,
       max_tokens: 2000,
-      system: [{ type: 'text', text: SYSTEM, cache_control: { type: 'ephemeral' } } as Anthropic.TextBlockParam],
+      system: systemBlocks,
       messages: [
         {
           role: 'user',
@@ -547,7 +591,13 @@ export async function plan(opts: {
   }
 }
 
-function parsePlan(text: string): PlannedScenario[] {
+/**
+ * Parse the Planner's response into scenarios. Accepts the rule-driven
+ * three-bracket format, the v3.1 two-bracket format, and all four legacy
+ * variants. Exported so smoke-plan-rule-tags locks the REAL parser (the older
+ * smoke-planner-parse predates the export and tests a mirror).
+ */
+export function parsePlan(text: string): PlannedScenario[] {
   const m = text.match(/<plan>([\s\S]*?)<\/plan>/i);
   const body = m && m[1] ? m[1] : text;
   const lines = body
@@ -556,17 +606,28 @@ function parsePlan(text: string): PlannedScenario[] {
     .filter((l) => /^\d+[.)]/.test(l));
   const out: PlannedScenario[] = [];
   for (const raw of lines) {
-    // First try the v3.1 format with explicit feature tag:
-    //   "1. [feature][category] name — rationale"
+    // First try the feature-tagged formats:
+    //   v4 (rule-driven): "1. [feature][category][R1,R3] name — rationale"
+    //                     "1. [feature][category][-] name — rationale"
+    //   v3.1:             "1. [feature][category] name — rationale"
+    // The third bracket is OPTIONAL: without a requirements map the model never
+    // emits it and this regex parses the v3.1 lines exactly as before.
     const withFeature = raw.match(
-      /^\d+[.)]\s*\[([a-z][a-z0-9-]*)\]\s*\[?(happy|negative|edge|a11y)\]?\s*[:\-—–]?\s*(.+?)\s*[—–]+\s*(.+)$/i,
+      /^\d+[.)]\s*\[([a-z][a-z0-9-]*)\]\s*\[?(happy|negative|edge|a11y)\]?\s*(?:\[\s*(-|[Rr]\d+(?:\s*,\s*[Rr]\d+)*)\s*\])?\s*[:\-—–]?\s*(.+?)\s*[—–]+\s*(.+)$/i,
     );
-    if (withFeature && withFeature[1] && withFeature[2] && withFeature[3] && withFeature[4]) {
+    if (withFeature && withFeature[1] && withFeature[2] && withFeature[4] && withFeature[5]) {
+      const ruleBracket = withFeature[3];
+      const ruleIds = ruleBracket === undefined
+        ? undefined
+        : ruleBracket.trim() === '-'
+          ? []
+          : ruleBracket.split(',').map((r) => r.trim().toUpperCase()).filter((r) => /^R\d+$/.test(r));
       out.push({
         feature: withFeature[1].toLowerCase(),
         category: withFeature[2].toLowerCase() as PlannedScenario['category'],
-        name: withFeature[3].trim(),
-        rationale: withFeature[4].trim(),
+        name: withFeature[4].trim(),
+        rationale: withFeature[5].trim(),
+        ...(ruleIds !== undefined ? { ruleIds } : {}),
       });
       continue;
     }

--- a/src/agent/requirements.ts
+++ b/src/agent/requirements.ts
@@ -1,0 +1,285 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Anthropic from '@anthropic-ai/sdk';
+import { normalizeFeatureName } from './parse-features.js';
+
+/**
+ * Requirements map — SRS ingestion for rule-driven planning.
+ *
+ * The user supplies a requirements document (SRS) in .md, .txt, .pdf, or
+ * .docx. One cheap Haiku call converts it into a structured RequirementsMap:
+ * features, per-feature rules with stable ids, and the roles the SRS names.
+ * The Planner then derives scenarios from the stated rules first and cites
+ * rule ids per scenario, and the run ends with a rule-coverage report.
+ *
+ * The map contains ONLY what the SRS states. The extraction prompt forbids
+ * inventing URLs or rules; a rule that is not in the document must not appear
+ * in the map.
+ */
+
+export interface RequirementRule {
+  /** Stable id, unique across the whole map: R1, R2, ... */
+  id: string;
+  /** The rule in plain words. */
+  text: string;
+  type: 'validation' | 'behavior' | 'permission' | 'navigation';
+}
+
+export interface RequirementFeature {
+  /** Kebab-case slug, same normalization as parse-features.ts. */
+  name: string;
+  /** One sentence. */
+  description: string;
+  /** Only present when the SRS states them. Never invented. */
+  urls?: string[];
+  rules: RequirementRule[];
+}
+
+export interface RequirementsMap {
+  features: RequirementFeature[];
+  /** User roles the SRS names. Empty when it names none. */
+  roles: string[];
+  /** True when the SRS text was cut at the extraction cap. */
+  truncated: boolean;
+}
+
+/** Cap on the SRS text sent to the model. */
+export const SRS_TEXT_CAP = 60_000;
+
+const SUPPORTED_EXTENSIONS = ['.md', '.txt', '.pdf', '.docx'];
+
+const HAIKU_MODEL = 'claude-haiku-4-5';
+// Haiku pricing per million tokens, same constants pattern as parse-features.ts.
+const PRICE = { in: 1.0, out: 5.0 };
+
+/**
+ * Read an SRS document into plain text. .md and .txt read directly; .pdf via
+ * pdf-parse; .docx via mammoth. Anything else is rejected with an error that
+ * names the supported extensions. Output is capped at SRS_TEXT_CAP characters;
+ * a longer document keeps the first SRS_TEXT_CAP and reports truncated=true.
+ */
+export async function loadSrsText(filePath: string): Promise<{ text: string; truncated: boolean }> {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`SRS file not found: ${filePath}`);
+  }
+  const ext = path.extname(filePath).toLowerCase();
+  let text: string;
+  switch (ext) {
+    case '.md':
+    case '.txt':
+      text = fs.readFileSync(filePath, 'utf8');
+      break;
+    case '.pdf': {
+      const { default: pdfParse } = await import('pdf-parse');
+      const parsed = await pdfParse(fs.readFileSync(filePath));
+      text = parsed.text;
+      break;
+    }
+    case '.docx': {
+      const { default: mammoth } = await import('mammoth');
+      const result = await mammoth.extractRawText({ buffer: fs.readFileSync(filePath) });
+      text = result.value;
+      break;
+    }
+    default:
+      throw new Error(
+        `Unsupported SRS file type "${ext || '(none)'}" for ${filePath}. ` +
+          `Supported: ${SUPPORTED_EXTENSIONS.join(', ')}.`,
+      );
+  }
+  if (text.length > SRS_TEXT_CAP) {
+    return { text: text.slice(0, SRS_TEXT_CAP), truncated: true };
+  }
+  return { text, truncated: false };
+}
+
+const SYSTEM = `You convert a software requirements document (SRS) into a structured map of features and testable rules.
+
+Extraction rules:
+- Extract ONLY what the document states. Never invent URLs, features, roles, or rules that are not in the text.
+- Include a "urls" array on a feature ONLY when the document states the URL. Omit the key otherwise.
+- Every validation constraint gets its OWN rule: each length limit, format requirement, required field, and value range is one rule, not a combined sentence.
+- Rule types: "validation" (input constraints), "behavior" (what the system does), "permission" (who may do what), "navigation" (where the user lands or may go).
+- Rule ids are R1, R2, R3, ... unique across the WHOLE document, in reading order.
+- Feature names are short lowercase kebab-case slugs (login, user-registration, cart).
+- "roles" lists the user roles the document names (admin, guest, ...). Empty array when it names none.
+
+Output STRICT JSON matching exactly this shape, and nothing else — no prose, no markdown fence:
+{
+  "features": [
+    {
+      "name": "kebab-case-slug",
+      "description": "one sentence",
+      "urls": ["only-when-stated"],
+      "rules": [
+        { "id": "R1", "text": "the rule in plain words", "type": "validation" }
+      ]
+    }
+  ],
+  "roles": []
+}`;
+
+const RULE_TYPES = new Set(['validation', 'behavior', 'permission', 'navigation']);
+
+/**
+ * Parse the model's response into the features + roles of a RequirementsMap.
+ * Defensive: strips a markdown fence if one sneaks in, tolerates prose around
+ * the JSON object, validates the shape, normalizes feature names to kebab-case,
+ * and re-numbers rule ids R1..Rn (in order) when the model's ids are missing or
+ * collide, so ids are always unique across the map. Throws on anything that
+ * cannot be recovered into the expected shape.
+ *
+ * Exported (pure, no API call) so the smoke test can drive the recovery paths.
+ */
+export function parseRequirementsResponse(text: string): Pick<RequirementsMap, 'features' | 'roles'> {
+  let body = text.trim();
+  // Strip a ```json ... ``` (or bare ```) fence.
+  const fence = body.match(/^```[a-z]*\s*([\s\S]*?)\s*```\s*$/i);
+  if (fence && fence[1]) body = fence[1].trim();
+  // Tolerate prose around the object: parse from the first "{" to the last "}".
+  const first = body.indexOf('{');
+  const last = body.lastIndexOf('}');
+  if (first >= 0 && last > first) body = body.slice(first, last + 1);
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(body);
+  } catch (err) {
+    throw new Error(`Requirements response is not valid JSON: ${(err as Error).message}`);
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Requirements response is not a JSON object.');
+  }
+  const obj = raw as { features?: unknown; roles?: unknown };
+  if (!Array.isArray(obj.features)) {
+    throw new Error('Requirements response has no "features" array.');
+  }
+
+  const features: RequirementFeature[] = [];
+  const seenIds = new Set<string>();
+  let idsValid = true;
+  for (const f of obj.features) {
+    if (typeof f !== 'object' || f === null) continue;
+    const fo = f as { name?: unknown; description?: unknown; urls?: unknown; rules?: unknown };
+    const name = normalizeFeatureName(typeof fo.name === 'string' ? fo.name : '');
+    if (!name) continue;
+    const rules: RequirementRule[] = [];
+    for (const r of Array.isArray(fo.rules) ? fo.rules : []) {
+      if (typeof r !== 'object' || r === null) continue;
+      const ro = r as { id?: unknown; text?: unknown; type?: unknown };
+      const ruleText = typeof ro.text === 'string' ? ro.text.trim() : '';
+      if (!ruleText) continue;
+      const id = typeof ro.id === 'string' ? ro.id.trim().toUpperCase() : '';
+      if (!/^R\d+$/.test(id) || seenIds.has(id)) idsValid = false;
+      seenIds.add(id);
+      const type = typeof ro.type === 'string' && RULE_TYPES.has(ro.type) ? (ro.type as RequirementRule['type']) : 'behavior';
+      rules.push({ id, text: ruleText, type });
+    }
+    const urls = Array.isArray(fo.urls)
+      ? fo.urls.filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
+      : [];
+    features.push({
+      name,
+      description: typeof fo.description === 'string' ? fo.description.trim() : '',
+      ...(urls.length > 0 ? { urls } : {}),
+      rules,
+    });
+  }
+  if (features.length === 0) {
+    throw new Error('Requirements response contained no usable features.');
+  }
+  // Guarantee unique sequential ids across the whole map when the model's ids
+  // are unusable. Renumbering happens BEFORE anything cites an id, so it is safe.
+  if (!idsValid) {
+    let n = 0;
+    for (const f of features) for (const r of f.rules) r.id = `R${++n}`;
+  }
+  const roles = Array.isArray(obj.roles)
+    ? obj.roles.filter((r): r is string => typeof r === 'string' && r.trim().length > 0).map((r) => r.trim())
+    : [];
+  return { features, roles };
+}
+
+export interface BuildRequirementsMapOptions {
+  srsText: string;
+  apiKey: string;
+  model?: string;
+  /** Set when loadSrsText already cut the document at the cap. */
+  truncated?: boolean;
+}
+
+/**
+ * One Haiku call that converts SRS text into a RequirementsMap. On a malformed
+ * response the call is retried once with a "return only valid JSON" reminder;
+ * a second failure throws with both parse errors named.
+ */
+export async function buildRequirementsMap(
+  opts: BuildRequirementsMapOptions,
+): Promise<{ map: RequirementsMap; costUsd: number }> {
+  const model = opts.model ?? HAIKU_MODEL;
+  const client = new Anthropic({ apiKey: opts.apiKey });
+  // Apply the cap here too, so a caller that skipped loadSrsText cannot send
+  // an unbounded document to the model.
+  const overCap = opts.srsText.length > SRS_TEXT_CAP;
+  const srsText = overCap ? opts.srsText.slice(0, SRS_TEXT_CAP) : opts.srsText;
+  const truncated = (opts.truncated ?? false) || overCap;
+
+  let costUsd = 0;
+  const ask = async (reminder?: string): Promise<string> => {
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: [{ type: 'text', text: SYSTEM, cache_control: { type: 'ephemeral' } } as Anthropic.TextBlockParam],
+      messages: [
+        { role: 'user', content: `${reminder ? reminder + '\n\n' : ''}SRS document:\n\n${srsText}` },
+      ],
+    });
+    const u = response.usage;
+    costUsd += (u.input_tokens * PRICE.in + u.output_tokens * PRICE.out) / 1_000_000;
+    return response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n');
+  };
+
+  let parsed: Pick<RequirementsMap, 'features' | 'roles'>;
+  try {
+    parsed = parseRequirementsResponse(await ask());
+  } catch (firstErr) {
+    try {
+      parsed = parseRequirementsResponse(
+        await ask('Your previous answer was not valid JSON. Return ONLY the JSON object, with no prose and no markdown fence.'),
+      );
+    } catch (secondErr) {
+      throw new Error(
+        `Could not extract a requirements map from the SRS. First attempt: ${(firstErr as Error).message} ` +
+          `Retry: ${(secondErr as Error).message}`,
+      );
+    }
+  }
+  return { map: { ...parsed, truncated }, costUsd };
+}
+
+/** Total rule count across every feature of a map. */
+export function countRules(map: RequirementsMap): number {
+  return map.features.reduce((n, f) => n + f.rules.length, 0);
+}
+
+/**
+ * Render a map as the REQUIREMENTS text block injected into the Planner's
+ * system prompt and the /generate context: each feature with its stated rules
+ * (id + type + text), plus the roles when the SRS names any.
+ */
+export function renderRequirementsBlock(map: RequirementsMap): string {
+  const lines: string[] = ['REQUIREMENTS (stated by the SRS — the source of truth for what to test):'];
+  for (const f of map.features) {
+    const urls = f.urls && f.urls.length > 0 ? ` (${f.urls.join(', ')})` : '';
+    lines.push(`- feature "${f.name}"${urls}: ${f.description}`);
+    for (const r of f.rules) {
+      lines.push(`    ${r.id} [${r.type}] ${r.text}`);
+    }
+  }
+  if (map.roles.length > 0) lines.push(`Roles named by the SRS: ${map.roles.join(', ')}`);
+  if (map.truncated) lines.push('Note: the SRS was truncated at the extraction cap; rules beyond the cap are not listed.');
+  return lines.join('\n');
+}

--- a/src/agent/rule-coverage.ts
+++ b/src/agent/rule-coverage.ts
@@ -1,0 +1,69 @@
+import type { RequirementsMap } from './requirements.js';
+
+/**
+ * Rule coverage — the "considered, not automated" report.
+ *
+ * Given the requirements map, the planned scenarios (which cite rule ids),
+ * and the scenarios that survived to the final report, classify every rule:
+ *
+ *   covered            — at least one surviving scenario cites the rule
+ *   planned-but-dropped — a planned scenario cited the rule, but no citing
+ *                         scenario survived the pipeline (gate / critic /
+ *                         replay / stability / findings)
+ *   not-planned        — no planned scenario cited the rule at all
+ *
+ * A run with a map ends with "X of Y rules covered" plus the named uncovered
+ * rules, so a rule that was considered but not automated is reported, never
+ * silently absent.
+ */
+
+export interface RuleCoverage {
+  covered: Array<{ ruleId: string; scenarios: string[] }>;
+  uncovered: Array<{ ruleId: string; text: string; reason: 'not-planned' | 'planned-but-dropped' }>;
+}
+
+/** The minimal scenario shape coverage needs: a name plus cited rule ids. */
+interface CitingScenario {
+  name: string;
+  ruleIds?: string[];
+}
+
+export function computeRuleCoverage(opts: {
+  map: RequirementsMap;
+  /** The plan as the Planner produced it (rule citations live here). */
+  planned: CitingScenario[];
+  /** Scenarios that survived to the final report. */
+  scenarios: CitingScenario[];
+}): RuleCoverage {
+  const covered: RuleCoverage['covered'] = [];
+  const uncovered: RuleCoverage['uncovered'] = [];
+  for (const feature of opts.map.features) {
+    for (const rule of feature.rules) {
+      const surviving = opts.scenarios.filter((s) => (s.ruleIds ?? []).includes(rule.id));
+      if (surviving.length > 0) {
+        covered.push({ ruleId: rule.id, scenarios: surviving.map((s) => s.name) });
+        continue;
+      }
+      const wasPlanned = opts.planned.some((p) => (p.ruleIds ?? []).includes(rule.id));
+      uncovered.push({
+        ruleId: rule.id,
+        text: rule.text,
+        reason: wasPlanned ? 'planned-but-dropped' : 'not-planned',
+      });
+    }
+  }
+  return { covered, uncovered };
+}
+
+/** Console lines for the end-of-run coverage summary. */
+export function renderRuleCoverage(coverage: RuleCoverage): string[] {
+  const total = coverage.covered.length + coverage.uncovered.length;
+  const lines: string[] = [`Rule coverage: ${coverage.covered.length} of ${total} rules covered`];
+  if (coverage.uncovered.length > 0) {
+    lines.push('  considered, not automated:');
+    for (const u of coverage.uncovered) {
+      lines.push(`    • ${u.ruleId} (${u.reason}) — ${u.text}`);
+    }
+  }
+  return lines;
+}

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -10,6 +10,8 @@ import { critique } from './critic.js';
 import { replay, type ReplayEvent } from './replay.js';
 import { stability, type StabilityEvent } from './stability.js';
 import { reconcile } from './reconcile.js';
+import { computeRuleCoverage, renderRuleCoverage } from './rule-coverage.js';
+import type { RequirementsMap } from './requirements.js';
 import { installEvalShim } from './eval-shim.js';
 import type { CascadeLevel } from './selectors.js';
 import { writeCsv } from './csv.js';
@@ -168,6 +170,12 @@ export interface ExploreOptions {
    * Ignored when `fromPlan` is supplied (the plan already defines scope).
    */
   features?: string[];
+  /**
+   * Optional requirements map built from an SRS (--srs). Flows to the Planner
+   * for rule-first planning, and the run ends with a rule-coverage report
+   * (report.ruleCoverage + rule-coverage.json in the output directory).
+   */
+  requirements?: RequirementsMap;
   onEvent?: (event: AgentEvent) => void;
 }
 
@@ -304,7 +312,7 @@ export async function explore(opts: ExploreOptions): Promise<RunReport | ReviewP
     // the expensive wandering this pipeline exists to prevent (a blind register
     // run burned the whole budget). Let plan()'s error propagate and stop the
     // run with its reason intact.
-    const p = await plan({ url: opts.url, apiKey, features: opts.features });
+    const p = await plan({ url: opts.url, apiKey, features: opts.features, requirements: opts.requirements });
 
     // A genuinely empty plan must also stop the run. Handing a blank plan to the
     // Explorer makes it design scenarios on the fly at full Opus cost. Fail loud
@@ -698,6 +706,13 @@ export async function explore(opts: ExploreOptions): Promise<RunReport | ReviewP
     ? { broken: brokenByGate, injections: gateInjectionLog }
     : undefined;
 
+  // SRS runs: carry each planned scenario's rule citations onto the emitted
+  // scenario that fulfilled it (matched by name), so ruleIds land in the
+  // RunReport and the emitted scenarios themselves.
+  if (opts.requirements) {
+    attachRuleIds(emittedScenarios, planResult.scenarios);
+  }
+
   const report: RunReport = {
     url: opts.url,
     language: opts.language,
@@ -722,11 +737,31 @@ export async function explore(opts: ExploreOptions): Promise<RunReport | ReviewP
   // all share one auditable funnel.
   report.reconciliation = reconcile(report);
 
+  // Rule coverage: classify every stated rule as covered, planned-but-dropped,
+  // or not-planned. Attached to the report and written to its own file so the
+  // "considered, not automated" list survives alongside run-report.json.
+  if (opts.requirements) {
+    report.ruleCoverage = computeRuleCoverage({
+      map: opts.requirements,
+      planned: planResult.scenarios,
+      scenarios: emittedScenarios,
+    });
+    for (const line of renderRuleCoverage(report.ruleCoverage)) {
+      opts.onEvent?.({ type: 'message', text: line });
+    }
+  }
+
   fs.mkdirSync(opts.outDir, { recursive: true });
   fs.writeFileSync(
     path.join(opts.outDir, 'run-report.json'),
     JSON.stringify(report, null, 2),
   );
+  if (report.ruleCoverage) {
+    fs.writeFileSync(
+      path.join(opts.outDir, 'rule-coverage.json'),
+      JSON.stringify(report.ruleCoverage, null, 2),
+    );
+  }
 
   // Persist what we learned for future runs against the same host.
   const resolvedIntents = collectResolvedIntents(scenarios);
@@ -761,6 +796,28 @@ function scenariosToCsv(url: string, scenarios: PlannedScenario[]): string {
     })),
     ['#', 'Category', 'Scenario', 'Rationale', 'Approve'],
   );
+}
+
+/**
+ * Copy each planned scenario's rule citations onto the emitted scenario that
+ * fulfilled it. Matching is by normalized name (exact first, then containment
+ * either way — the Explorer occasionally rephrases a planned name slightly).
+ * A scenario with no matching plan entry, or whose plan entry cited no rules,
+ * is left untouched.
+ */
+function attachRuleIds(scenarios: Scenario[], planned: PlannedScenario[]): void {
+  const key = (s: string): string => s.toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
+  for (const s of scenarios) {
+    const k = key(s.name);
+    if (!k) continue;
+    const match =
+      planned.find((p) => key(p.name) === k) ??
+      planned.find((p) => {
+        const pk = key(p.name);
+        return pk.length > 0 && (k.includes(pk) || pk.includes(k));
+      });
+    if (match?.ruleIds && match.ruleIds.length > 0) s.ruleIds = [...match.ruleIds];
+  }
 }
 
 /** Walk every scenario's trace and collect the intent + cascade level each selector resolved at. */

--- a/src/agent/trace.ts
+++ b/src/agent/trace.ts
@@ -249,6 +249,11 @@ export interface Scenario {
    * legacy URL-pathname grouping in that case.
    */
   feature?: string;
+  /**
+   * Requirement rule ids this scenario verifies, inherited from the planned
+   * scenario it fulfils (SRS runs only). Absent without a requirements map.
+   */
+  ruleIds?: string[];
   steps: TraceStep[];
   /** Console messages of level 'error' / 'warning' that fired during the scenario. */
   consoleErrors?: Array<{ kind: 'error' | 'warning'; text: string }>;
@@ -279,7 +284,7 @@ export interface RunReport {
   startedAt: string;
   finishedAt: string;
   /** Scenarios proposed by the Planner before the Explorer ran. */
-  plan?: Array<{ name: string; category: string; rationale: string }>;
+  plan?: Array<{ name: string; category: string; rationale: string; feature?: string; ruleIds?: string[] }>;
   /** Per-scenario verdicts from the Critic. */
   review?: {
     verdicts: Array<{
@@ -410,4 +415,9 @@ export interface RunReport {
    * reconcile.ts.
    */
   reconciliation?: import('./reconcile.js').Reconciliation;
+  /**
+   * Rule coverage against the requirements map (SRS runs only). Also written
+   * to rule-coverage.json in the run output directory. Absent without --srs.
+   */
+  ruleCoverage?: import('./rule-coverage.js').RuleCoverage;
 }

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -6,6 +6,8 @@ import { transcribe } from '../agent/transcriber.js';
 import { scaffold, frameworkDirName, normalizeAndValidateUrl } from '../agent/scaffold.js';
 import { zipFrameworkToFile } from '../agent/zip-framework.js';
 import { parseCommaSeparated } from '../agent/parse-features.js';
+import { buildRequirementsMap, countRules, loadSrsText, type RequirementsMap } from '../agent/requirements.js';
+import { renderRuleCoverage } from '../agent/rule-coverage.js';
 import { readCsv } from '../agent/csv.js';
 import { renderReconciliation } from '../agent/reconcile.js';
 import type { PlannedScenario } from '../agent/planner.js';
@@ -50,6 +52,12 @@ interface ParsedArgs {
    * is a separate piece of work (deferred).
    */
   features: string[];
+  /**
+   * Path to an SRS document (--srs). Loaded and converted to a requirements
+   * map before the browser launches; the map steers rule-first planning and
+   * produces the rule-coverage report.
+   */
+  srs?: string;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -103,12 +111,20 @@ function parseArgs(argv: string[]): ParsedArgs {
       }
       parsed.features = parseCommaSeparated(v);
     }
+    else if (a === '--srs') {
+      const v = args[++i];
+      if (!v) {
+        console.error('✗ --srs expects a file path (.md, .txt, .pdf, or .docx)');
+        process.exit(1);
+      }
+      parsed.srs = v;
+    }
     else if (a && !parsed.url) parsed.url = a;
   }
   if (!parsed.url && !parsed.fromPlan) {
     console.error('Usage:');
     console.error('  npm run explore -- <url> [--lang ts|js] [--name foo] [--out dir] [--review]');
-    console.error('                          [--features login,cart] [--no-pom] [--no-replay]');
+    console.error('                          [--features login,cart] [--srs requirements.md] [--no-pom] [--no-replay]');
     console.error('                          [--no-stability] [--stability N] [--no-stabilize]');
     console.error('                          [--stabilize-attempts N]');
     console.error('  npm run explore -- --from-plan <plan.csv> [--lang ts|js] [--name foo] [--no-pom]');
@@ -228,6 +244,34 @@ async function main(): Promise<void> {
   console.log(`  output:   ${path.relative(process.cwd(), outDir)}`);
   console.log('');
 
+  // SRS ingestion — all of it happens BEFORE the browser launches, so a bad
+  // document or an empty map fails fast and free.
+  let requirements: RequirementsMap | undefined;
+  if (args.srs) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      console.error('✗ --srs needs ANTHROPIC_API_KEY set (the requirements map is built with a Haiku call).');
+      process.exit(1);
+    }
+    const { text, truncated } = await loadSrsText(args.srs);
+    const built = await buildRequirementsMap({ srsText: text, truncated, apiKey });
+    requirements = built.map;
+    if (requirements.features.length === 0) {
+      console.error(`✗ The SRS at ${args.srs} yielded no features. Nothing to plan from — check the document.`);
+      process.exit(1);
+    }
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'requirements-map.json'), JSON.stringify(requirements, null, 2));
+    console.log(
+      `  SRS: ${requirements.features.length} feature(s), ${countRules(requirements)} rule(s) · $${built.costUsd.toFixed(4)}` +
+      `${requirements.truncated ? ' · truncated at cap' : ''}`,
+    );
+    if (args.features.length > 0) {
+      console.log('  (--features wins for feature selection; the SRS rules still steer the Planner)');
+    }
+    console.log('');
+  }
+
   const specName = args.name ?? slug(url);
   const lang = args.lang;
 
@@ -242,6 +286,7 @@ async function main(): Promise<void> {
     stabilize: args.stabilize,
     maxStabilizeAttempts: args.stabilizeAttempts,
     features: args.features,
+    requirements,
     onEvent: (e) => {
       switch (e.type) {
         case 'plan_started':
@@ -435,6 +480,10 @@ async function main(): Promise<void> {
     console.log('');
     for (const line of renderReconciliation(result.reconciliation)) console.log(line);
   }
+  if (result.ruleCoverage) {
+    console.log('');
+    for (const line of renderRuleCoverage(result.ruleCoverage)) console.log(line);
+  }
   // v3: the new framework workflow is "cd into it and use it as a project".
   // For backward compat with --no-pom, still show the single-file command.
   if (args.pom) {
@@ -457,20 +506,24 @@ function hostnameOf(url: string): string {
 
 /**
  * After the zip is written, replace the on-disk framework directory with a
- * stub that contains only `run-report.json`. The zip is the deliverable;
- * the dir stays as a tombstone so the dashboard's run-history scan still
- * recognises this run.
+ * stub that contains only the run reports: `run-report.json`, plus (on SRS
+ * runs) `requirements-map.json` and `rule-coverage.json`. The zip is the
+ * deliverable; the dir stays as a tombstone so the dashboard's run-history
+ * scan still recognises this run and the rule-coverage report stays
+ * inspectable without unzipping.
  */
 function slimFrameworkDir(dir: string): void {
-  const reportPath = path.join(dir, 'run-report.json');
-  let reportContent: string | null = null;
-  if (fs.existsSync(reportPath)) {
-    try { reportContent = fs.readFileSync(reportPath, 'utf8'); } catch { /* leave null */ }
+  const KEEP = ['run-report.json', 'requirements-map.json', 'rule-coverage.json'];
+  const kept: Array<{ name: string; content: string }> = [];
+  for (const name of KEEP) {
+    const p = path.join(dir, name);
+    if (!fs.existsSync(p)) continue;
+    try { kept.push({ name, content: fs.readFileSync(p, 'utf8') }); } catch { /* skip */ }
   }
   try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
-  if (reportContent !== null) {
+  if (kept.length > 0) {
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(reportPath, reportContent);
+    for (const f of kept) fs.writeFileSync(path.join(dir, f.name), f.content);
   }
 }
 

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -2,34 +2,45 @@ import 'dotenv/config';
 import fs from 'node:fs';
 import path from 'node:path';
 import { generateFromStory } from '../agent/generate.js';
+import { buildRequirementsMap, countRules, loadSrsText, type RequirementsMap } from '../agent/requirements.js';
 
 /**
- * CLI:  npm run generate -- "<story>" [--lang ts|js] [--base-url <url>] [--out <dir>]
+ * CLI:  npm run generate -- "<story>" [--lang ts|js] [--base-url <url>] [--out <dir>] [--srs <file>]
  *
  * Single-shot story → spec. The spec is marked UNVERIFIED — run it before trusting it.
+ * With --srs, the requirements document is converted to a rules map that is
+ * injected as context, so the generated tests verify the documented constraints.
  */
 
 function parseArgs(argv: string[]): {
-  story: string; lang: 'ts' | 'js'; baseUrl?: string; outBase?: string;
+  story: string; lang: 'ts' | 'js'; baseUrl?: string; outBase?: string; srs?: string;
 } {
   const args = argv.slice(2);
   let lang: 'ts' | 'js' = 'ts';
   let baseUrl: string | undefined;
   let outBase: string | undefined;
+  let srs: string | undefined;
   const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--lang') { const v = args[++i]; lang = (v === 'js' ? 'js' : 'ts'); }
     else if (a === '--base-url') baseUrl = args[++i];
     else if (a === '--out') outBase = args[++i];
+    else if (a === '--srs') {
+      srs = args[++i];
+      if (!srs) {
+        console.error('✗ --srs expects a file path (.md, .txt, .pdf, or .docx)');
+        process.exit(1);
+      }
+    }
     else if (a) positional.push(a);
   }
   const story = positional.join(' ').trim();
   if (!story) {
-    console.error('Usage: npm run generate -- "<user story>" [--lang ts|js] [--base-url https://...] [--out dir]');
+    console.error('Usage: npm run generate -- "<user story>" [--lang ts|js] [--base-url https://...] [--out dir] [--srs requirements.md]');
     process.exit(1);
   }
-  return { story, lang, baseUrl, outBase };
+  return { story, lang, baseUrl, outBase, srs };
 }
 
 function runId(): string {
@@ -39,7 +50,7 @@ function runId(): string {
 }
 
 async function main(): Promise<void> {
-  const { story, lang, baseUrl, outBase } = parseArgs(process.argv);
+  const { story, lang, baseUrl, outBase, srs } = parseArgs(process.argv);
   const base = outBase ?? path.join(process.cwd(), 'output');
   const id = `${runId()}-generate`;
   const outDir = path.join(base, id);
@@ -49,7 +60,20 @@ async function main(): Promise<void> {
   console.log(`  language: ${lang}`);
   console.log(`  output:   ${path.relative(process.cwd(), outDir)}\n`);
 
-  const { feature, scenarios, spec } = await generateFromStory({ story, language: lang, baseUrl });
+  let requirements: RequirementsMap | undefined;
+  if (srs) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      console.error('✗ --srs needs ANTHROPIC_API_KEY set (the requirements map is built with a Haiku call).');
+      process.exit(1);
+    }
+    const { text, truncated } = await loadSrsText(srs);
+    const built = await buildRequirementsMap({ srsText: text, truncated, apiKey });
+    requirements = built.map;
+    console.log(`  SRS: ${requirements.features.length} feature(s), ${countRules(requirements)} rule(s) · $${built.costUsd.toFixed(4)}${requirements.truncated ? ' · truncated at cap' : ''}\n`);
+  }
+
+  const { feature, scenarios, spec } = await generateFromStory({ story, language: lang, baseUrl, requirements });
   const file = `${slug(feature)}.spec.${lang}`;
   const specPath = path.join(outDir, file);
 


### PR DESCRIPTION
Phase 2 lets the user hand the agent a requirements document (SRS): the agent builds a structured requirements map before planning, plans from the stated rules, and reports rule coverage at the end of the run. One commit (661a4dd), six tasks.

## Task 1: requirements map module

New `src/agent/requirements.ts`. `loadSrsText` reads `.md`/`.txt` directly, `.pdf` via pdf-parse, `.docx` via mammoth (both added as dependencies), rejects other extensions naming the supported ones, and caps extracted text at 60,000 characters with `truncated=true` beyond it. `buildRequirementsMap` is one Haiku call (claude-haiku-4-5, same pricing-constants pattern as parse-features.ts) returning `{ map, costUsd }`. The `RequirementsMap` type carries features (kebab-case name, description, urls only when stated, rules with unique ids R1..Rn typed validation/behavior/permission/navigation), roles, and the truncated flag. The extraction prompt forbids inventing URLs or rules and makes every validation constraint its own rule. Parsing is defensive: fence stripping, prose tolerance, one "return only valid JSON" retry, then a clear error; the parse step (`parseRequirementsResponse`) is exported so it is testable without an API call.

## Task 2: CLI wiring

`npm run explore -- <url> --srs <file>` loads the SRS, builds the map before the browser launches, writes `requirements-map.json` into the run directory, and prints a one-line summary (features, rules, cost). An SRS that yields zero features fails loudly pre-browser. When `--features` is also set, the flag wins for feature selection while the map still flows to the Planner for rule context. `npm run generate -- "<story>" --srs <file>` passes the map into `generateFromStory`, which now accepts an optional requirements map and injects it into its prompt as context.

## Task 3: rule-driven planning

With a map present, the Planner's system prompt gains a REQUIREMENTS block (appended after the cached base block, so the cache prefix is untouched) listing each feature's rules with id, type, and text. Planning becomes rule-first: scenarios derive from stated rules before DOM evidence, every rule-verifying scenario cites its ids in a third bracket (`[login][negative][R3,R7] rejected a 5-character password`), page-discovered scenarios use `[-]`, and the ceiling becomes up to 4 scenarios per map feature (still at least one happy, one negative, one edge per feature whose rules support them). The falsifiability doctrine is unchanged. `parsePlan` (now exported) reads the bracket into `PlannedScenario.ruleIds` and tolerates its absence: without `--srs` the Planner's input and output format are byte-identical to before this phase.

## Task 4: rule coverage report

`Scenario.ruleIds` carries citations through trace.ts into the RunReport (attached by name-matching emitted scenarios back to the plan). New `src/agent/rule-coverage.ts` classifies every rule as covered (with the surviving scenario names), `not-planned`, or `planned-but-dropped` (a citing scenario existed but did not survive the pipeline). The run writes `rule-coverage.json` next to `run-report.json` and ends with `Rule coverage: X of Y rules covered` plus the named uncovered list, the considered-not-automated report. The post-zip slimming keeps both new JSON files on disk alongside `run-report.json`.

## Task 5: smoke locks

Three new offline smokes, no LLM, no network: `smoke-srs-parse` (20 checks: loading, the 60k cap, the unsupported-extension error, and the JSON recovery paths of the exported parser), `smoke-plan-rule-tags` (22 checks: rule ids, `[-]`, and the old two-bracket plus all four legacy formats parsing unchanged with no `ruleIds` key, against the real exported parser), `smoke-rule-coverage` (12 checks: covered, not-planned, planned-but-dropped, and the rendered summary).

## Task 6: docs

README gains an "SRS-first workflow" section with the map shape and the rule-citation bracket; DOCUMENTATION.md documents `--srs` on both commands, the workflow, and the two new output files; CLAUDE.md gains invariant 26, including the no-`--srs` byte-identical guarantee locked by `smoke-plan-rule-tags`.

## Verification

- `npx tsc --noEmit` is clean.
- Full smoke suite: **39/39 pass** (36 existing plus the three new SRS smokes; the new three contribute 54 checks).
- The `.pdf` load path was additionally exercised live (Chromium-printed PDF through `loadSrsText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
